### PR TITLE
Adding -r flag only if the port has changed.

### DIFF
--- a/frameworks/portworx/src/main/dist/svc.yml
+++ b/frameworks/portworx/src/main/dist/svc.yml
@@ -67,6 +67,11 @@ pods:
                 PORTWORX_KVDB={{PORTWORX_KVDB_SERVERS}}
                 {{/ETCD_ENABLED}}
 
+                startPort={{PORTWORX_START_PORT}}
+                if [[ "$startPort" != "9001" ]]; then
+                    START_PORT_OPTION="-r $startPort"
+                fi
+
                 echo "[Unit]
                     Description=Portworx Container
                     Before=docker.service
@@ -97,8 +102,7 @@ pods:
                           {{/SECRETS_ENABLED}}
                           -name=%n \
                           -c {{PORTWORX_CLUSTER_NAME}} {{{PORTWORX_OPTIONS}}} \
-                          -r {{PORTWORX_START_PORT}} \
-                          -k $PORTWORX_KVDB
+                          $START_PORT_OPTION -k $PORTWORX_KVDB
                     KillMode=control-group
                     ExecStop=/opt/pwx/bin/runc kill %n
                     [Install]

--- a/frameworks/portworx/universe/package.json
+++ b/frameworks/portworx/universe/package.json
@@ -1,6 +1,6 @@
 {
   "packagingVersion": "4.0",
-  "upgradesFrom": [],
+  "upgradesFrom": ["1.3-1.4.2.1"],
   "downgradesTo": [],
   "minDcosReleaseVersion": "1.9",
   "name": "portworx",


### PR DESCRIPTION
Adding the flag blindly breaks in older version of Portworx as -r was not supported
before 1.3.6