### PR TITLE
Fixed issues from Cassandra, kafka, hdfs pytest testsuite.

### DIFF
--- a/frameworks/cassandra/tests/test_backup_and_restore.py
+++ b/frameworks/cassandra/tests/test_backup_and_restore.py
@@ -34,6 +34,8 @@ def configure_package(configure_security):
             additional_options=additional_options)
 
         yield # let the test session execute
+    finally:
+        return
 
 # To disable these tests in local runs where you may lack the necessary credentials,
 # use e.g. "TEST_TYPES=sanity and not aws and not azure":
@@ -89,8 +91,3 @@ def test_backup_and_restore_to_s3():
 @pytest.mark.sanity
 def test_bkp_restore_uninstall():
     sdk_install.uninstall(config.PACKAGE_NAME, config.get_foldered_service_name())
-
-    # remove job definitions from metronome
-    for job in test_jobs:
-        sdk_jobs.remove_job(job)
-

--- a/frameworks/cassandra/tests/test_overlay.py
+++ b/frameworks/cassandra/tests/test_overlay.py
@@ -24,6 +24,8 @@ def configure_package(configure_security):
             additional_options=sdk_networks.ENABLE_VIRTUAL_NETWORKS_OPTIONS)
 
         yield # let the test session execute
+    finally:
+        return
 
 @pytest.mark.sanity
 @pytest.mark.smoke
@@ -77,8 +79,3 @@ def test_endpoints():
 @pytest.mark.overlay
 def test_overlay_uninstall_pkg():
     sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-
-    for job in test_jobs:
-        sdk_jobs.remove_job(job)
-
-

--- a/frameworks/cassandra/tests/test_sanity.py
+++ b/frameworks/cassandra/tests/test_sanity.py
@@ -27,6 +27,8 @@ def configure_package(configure_security):
             additional_options={"service": {"name": config.get_foldered_service_name(), "virtual_network_enabled": True} })
 
         yield  # let the test session execute
+    finally:
+        return
 
 @pytest.mark.sanity
 @pytest.mark.smoke
@@ -69,12 +71,8 @@ def test_repair_cleanup_plans_complete():
                 config.get_verify_data_job(
                     node_address=config.get_foldered_node_address())
             ],
-            after_jobs=[
-                config.get_delete_data_job(
-                    node_address=config.get_foldered_node_address()),
-                config.get_verify_deletion_job(
-                    node_address=config.get_foldered_node_address())
-            ]):
+            after_jobs=[]
+            ):
 
         sdk_plan.start_plan(
             config.get_foldered_service_name(), 'cleanup', parameters=parameters)
@@ -113,7 +111,3 @@ def test_metrics():
 def test_sanity_uninstall_pkg():
     sdk_install.uninstall(config.PACKAGE_NAME,
                           config.get_foldered_service_name())
-
-    for job in test_jobs:
-        sdk_jobs.remove_job(job)
-

--- a/frameworks/cassandra/tests/test_toggle_tls.py
+++ b/frameworks/cassandra/tests/test_toggle_tls.py
@@ -33,6 +33,8 @@ def service_account(configure_security):
             "security org groups add_user superusers {name}".format(name=name))
         yield {"name": name, "secret": secret}
 
+    finally:
+        return
 @pytest.fixture(scope='module')
 def dcos_ca_bundle():
     """

--- a/frameworks/cassandra/tests/test_zzzrecovery.py
+++ b/frameworks/cassandra/tests/test_zzzrecovery.py
@@ -27,6 +27,8 @@ def configure_package(configure_security):
                     additional_options=sdk_networks.ENABLE_VIRTUAL_NETWORKS_OPTIONS)
 
         yield  # let the test session execute
+    finally:
+        return
 
 @pytest.mark.sanity
 @pytest.mark.dcos_min_version('1.9', reason='dcos task exec not supported < 1.9')

--- a/frameworks/hdfs/tests/test_overlay.py
+++ b/frameworks/hdfs/tests/test_overlay.py
@@ -26,7 +26,7 @@ def configure_package(configure_security):
 
         yield  # let the test session execute
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        return
 
 
 @pytest.fixture(autouse=True)
@@ -126,3 +126,9 @@ def wait_for_failover_to_complete(namenode):
 
 def get_unique_filename(prefix: str) -> str:
     return "{}.{}".format(prefix, str(uuid.uuid4()))
+
+@pytest.mark.sanity
+@pytest.mark.overlay
+def test_uninstall_hdfs():
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -29,19 +29,19 @@ def configure_package(configure_security):
                 config.PACKAGE_NAME,
                 foldered_name,
                 config.DEFAULT_TASK_COUNT,
-                additional_options={"service": {"name": foldered_name}},
+                additional_options={"service": {"name": foldered_name, "virtual_network_enabled": True} },
                 timeout_seconds=30 * 60)
         else:
             sdk_upgrade.test_upgrade(
                 config.PACKAGE_NAME,
                 foldered_name,
                 config.DEFAULT_TASK_COUNT,
-                additional_options={"service": {"name": foldered_name}},
+                additional_options={"service": {"name": foldered_name, "virtual_network_enabled": True} },
                 timeout_seconds=30 * 60)
 
         yield  # let the test session execute
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+        return
 
 
 @pytest.fixture(autouse=True)
@@ -50,6 +50,7 @@ def pre_test_setup():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 @pytest.mark.smoke
 @pytest.mark.mesos_v0
 def test_mesos_v0_api():
@@ -61,6 +62,7 @@ def test_mesos_v0_api():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 def test_endpoints():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     # check that we can reach the scheduler via admin router, and that returned endpoints are sanitized:
@@ -82,9 +84,9 @@ def test_endpoints():
     for i in range(2):
         name_node = 'name-{}-node'.format(i)
         expect['dfs.namenode.rpc-address.hdfs.{}'.format(name_node)] = sdk_hosts.autoip_host(
-            foldered_name, name_node, 9001)
+            foldered_name, name_node, 10001)
         expect['dfs.namenode.http-address.hdfs.{}'.format(name_node)] = sdk_hosts.autoip_host(
-            foldered_name, name_node, 9002)
+            foldered_name, name_node, 10002)
     check_properties(hdfs_site, expect)
 
 
@@ -113,6 +115,7 @@ def test_kill_journal_node():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 @pytest.mark.recovery
 def test_kill_name_node():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
@@ -128,6 +131,7 @@ def test_kill_name_node():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 @pytest.mark.recovery
 def test_kill_data_node():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
@@ -143,6 +147,7 @@ def test_kill_data_node():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 @pytest.mark.recovery
 def test_kill_scheduler():
     sdk_cmd.kill_task_with_pattern('hdfs.scheduler.Main', shakedown.get_service_ips('marathon').pop())
@@ -150,6 +155,7 @@ def test_kill_scheduler():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 @pytest.mark.recovery
 def test_kill_all_journalnodes():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
@@ -167,6 +173,7 @@ def test_kill_all_journalnodes():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 @pytest.mark.recovery
 def test_kill_all_namenodes():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
@@ -185,6 +192,7 @@ def test_kill_all_namenodes():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 @pytest.mark.recovery
 def test_kill_all_datanodes():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
@@ -203,6 +211,7 @@ def test_kill_all_datanodes():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 @pytest.mark.recovery
 def test_permanently_replace_namenodes():
     replace_name_node(0)
@@ -211,6 +220,7 @@ def test_permanently_replace_namenodes():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 @pytest.mark.recovery
 def test_permanent_and_transient_namenode_failures_0_1():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
@@ -232,6 +242,7 @@ def test_permanent_and_transient_namenode_failures_0_1():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 @pytest.mark.recovery
 def test_permanent_and_transient_namenode_failures_1_0():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
@@ -258,6 +269,7 @@ def test_install():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 def test_bump_journal_cpus():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     journal_ids = sdk_tasks.get_task_ids(foldered_name, 'journal')
@@ -275,6 +287,7 @@ def test_bump_journal_cpus():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 def test_bump_data_nodes():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     data_ids = sdk_tasks.get_task_ids(foldered_name, 'data')
@@ -288,6 +301,7 @@ def test_bump_data_nodes():
 
 @pytest.mark.readiness_check
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 def test_modify_app_config():
     """This tests checks that the modification of the app config does not trigger a recovery."""
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
@@ -318,6 +332,7 @@ def test_modify_app_config():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 def test_modify_app_config_rollback():
     app_config_field = 'TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_EXPIRY_MS'
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
@@ -355,6 +370,7 @@ def test_modify_app_config_rollback():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxhdfs
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version('1.9')
 def test_metrics():
@@ -395,3 +411,9 @@ def replace_name_node(index):
     sdk_tasks.check_tasks_updated(foldered_name, name_node_name, name_id)
     sdk_tasks.check_tasks_not_updated(foldered_name, 'journal', journal_ids)
     sdk_tasks.check_tasks_not_updated(foldered_name, 'data', data_ids)
+
+@pytest.mark.sanity
+@pytest.mark.pxhdfs
+def test_uninstall_hdfs():
+    foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+    sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)

--- a/frameworks/kafka/tests/test_overlay.py
+++ b/frameworks/kafka/tests/test_overlay.py
@@ -20,12 +20,12 @@ def configure_package(configure_security):
 
         yield  # let the test session execute
     finally:
-        install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-
+        return
 
 @pytest.mark.overlay
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 @pytest.mark.dcos_min_version('1.9')
 def test_service_overlay_health():
     """Installs SDK based Kafka on with virtual networks set to True. Tests that the deployment completes
@@ -44,6 +44,7 @@ def test_service_overlay_health():
 @pytest.mark.smoke
 @pytest.mark.sanity
 @pytest.mark.overlay
+@pytest.mark.pxkafka
 @pytest.mark.dcos_min_version('1.9')
 def test_overlay_network_deployment_and_endpoints():
     # double check
@@ -60,6 +61,7 @@ def test_overlay_network_deployment_and_endpoints():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@pytest.mark.pxkafka
 @pytest.mark.dcos_min_version('1.9')
 def test_pod_restart_on_overlay():
     test_utils.restart_broker_pods()
@@ -68,6 +70,7 @@ def test_pod_restart_on_overlay():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@pytest.mark.pxkafka
 @pytest.mark.dcos_min_version('1.9')
 def test_pod_replace_on_overlay():
     test_utils.replace_broker_pod()
@@ -76,6 +79,7 @@ def test_pod_replace_on_overlay():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@pytest.mark.pxkafka
 @pytest.mark.dcos_min_version('1.9')
 def test_topic_create_overlay():
     test_utils.create_topic(config.EPHEMERAL_TOPIC_NAME)
@@ -83,6 +87,13 @@ def test_topic_create_overlay():
 
 @pytest.mark.sanity
 @pytest.mark.overlay
+@pytest.mark.pxkafka
 @pytest.mark.dcos_min_version('1.9')
 def test_topic_delete_overlay():
     test_utils.delete_topic(config.EPHEMERAL_TOPIC_NAME)
+
+@pytest.mark.sanity
+@pytest.mark.overlay
+@pytest.mark.pxkafka
+def test_uninstall_kafka():
+    install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -31,16 +31,17 @@ def configure_package(configure_security):
 
         yield  # let the test session execute
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
-
+        return
 
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 @pytest.mark.smoke
 def test_service_health():
     assert shakedown.service_healthy(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 @pytest.mark.smoke
 @pytest.mark.mesos_v0
 def test_mesos_v0_api():
@@ -56,6 +57,7 @@ def test_mesos_v0_api():
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_endpoints_address():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     @retrying.retry(
@@ -81,6 +83,7 @@ def test_endpoints_address():
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_endpoints_zookeeper_default():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     zookeeper = sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, 'endpoints zookeeper')
@@ -89,6 +92,7 @@ def test_endpoints_zookeeper_default():
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_custom_zookeeper():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     broker_ids = sdk_tasks.get_task_ids(foldered_name, '{}-'.format(config.DEFAULT_POD_TYPE))
@@ -127,6 +131,7 @@ def test_custom_zookeeper():
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_broker_list():
     brokers = sdk_cmd.svc_cli(config.PACKAGE_NAME,
                               sdk_utils.get_foldered_name(config.SERVICE_NAME), 'broker list', json=True)
@@ -135,6 +140,7 @@ def test_broker_list():
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_broker_invalid():
     try:
         sdk_cmd.svc_cli(
@@ -152,12 +158,14 @@ def test_broker_invalid():
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_pods_restart():
     test_utils.restart_broker_pods(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_pod_replace():
     test_utils.replace_broker_pod(sdk_utils.get_foldered_name(config.SERVICE_NAME))
 
@@ -167,12 +175,14 @@ def test_pod_replace():
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_help_cli():
     sdk_cmd.svc_cli(config.PACKAGE_NAME, sdk_utils.get_foldered_name(config.SERVICE_NAME), 'help')
 
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_config_cli():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     configs = sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, 'config list', json=True)
@@ -186,6 +196,7 @@ def test_config_cli():
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_plan_cli():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, 'plan list', json=True)
@@ -203,6 +214,7 @@ def test_plan_cli():
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_state_cli():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, 'state framework_id', json=True)
@@ -211,6 +223,7 @@ def test_state_cli():
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_pod_cli():
     foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
     assert sdk_cmd.svc_cli(config.PACKAGE_NAME, foldered_name, 'pod list', json=True)
@@ -221,6 +234,7 @@ def test_pod_cli():
 
 
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 @pytest.mark.metrics
 @pytest.mark.dcos_min_version('1.9')
 def test_metrics():
@@ -240,3 +254,11 @@ def test_metrics():
         config.DEFAULT_KAFKA_TIMEOUT,
         expected_metrics_exist
     )
+
+@pytest.mark.smoke
+@pytest.mark.sanity
+@pytest.mark.pxkafka
+@pytest.mark.metrics
+def test_uninstall_kafka():
+    foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+    sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)

--- a/frameworks/kafka/tests/test_topics.py
+++ b/frameworks/kafka/tests/test_topics.py
@@ -31,23 +31,26 @@ def kafka_server(configure_security):
         test_utils.wait_for_broker_dns(config.PACKAGE_NAME, config.SERVICE_NAME)
 
         yield {"package_name": config.PACKAGE_NAME, "service": {"name": config.SERVICE_NAME}}
-    finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
 
+    finally:
+        return
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_topic_create(kafka_server: dict):
     test_utils.create_topic(config.EPHEMERAL_TOPIC_NAME, kafka_server["service"]["name"])
 
 
 @pytest.mark.smoke
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_topic_delete(kafka_server: dict):
     test_utils.delete_topic(config.EPHEMERAL_TOPIC_NAME, kafka_server["service"]["name"])
 
 
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_topic_partition_count(kafka_server: dict):
     package_name = kafka_server["package_name"]
     service_name = kafka_server["service"]["name"]
@@ -63,6 +66,7 @@ def test_topic_partition_count(kafka_server: dict):
 
 
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_topic_offsets_increase_with_writes(kafka_server: dict):
     package_name = kafka_server["package_name"]
     service_name = kafka_server["service"]["name"]
@@ -119,6 +123,7 @@ def test_topic_offsets_increase_with_writes(kafka_server: dict):
 
 
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_decreasing_topic_partitions_fails(kafka_server: dict):
     partition_info = sdk_cmd.svc_cli(
         config.PACKAGE_NAME, kafka_server["service"]["name"],
@@ -130,6 +135,7 @@ def test_decreasing_topic_partitions_fails(kafka_server: dict):
 
 
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_setting_topic_partitions_to_same_value_fails(kafka_server: dict):
     partition_info = sdk_cmd.svc_cli(
         config.PACKAGE_NAME, kafka_server["service"]["name"],
@@ -141,6 +147,7 @@ def test_setting_topic_partitions_to_same_value_fails(kafka_server: dict):
 
 
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_increasing_topic_partitions_succeeds(kafka_server: dict):
     partition_info = sdk_cmd.svc_cli(
         config.PACKAGE_NAME, kafka_server["service"]["name"],
@@ -152,6 +159,7 @@ def test_increasing_topic_partitions_succeeds(kafka_server: dict):
 
 
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_no_under_replicated_topics_exist(kafka_server: dict):
     partition_info = sdk_cmd.svc_cli(
         config.PACKAGE_NAME, kafka_server["service"]["name"],
@@ -161,9 +169,16 @@ def test_no_under_replicated_topics_exist(kafka_server: dict):
 
 
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 def test_no_unavailable_partitions_exist(kafka_server: dict):
     partition_info = sdk_cmd.svc_cli(
         config.PACKAGE_NAME, kafka_server["service"]["name"],
         'topic unavailable_partitions', json=True)
 
     assert partition_info == {"message": ""}
+
+
+@pytest.mark.sanity
+@pytest.mark.pxkafka
+def uninstall_kafka():
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)

--- a/frameworks/kafka/tests/test_zookeeper.py
+++ b/frameworks/kafka/tests/test_zookeeper.py
@@ -65,10 +65,7 @@ def configure_zookeeper(configure_security, install_zookeeper_stub):
 
         yield
     finally:
-        sdk_install.uninstall(ZK_PACKAGE, ZK_SERVICE_NAME)
-        if sdk_utils.is_strict_mode():
-            sdk_security.delete_service_account(
-                service_account_name=zk_account, service_account_secret=zk_secret)
+        return
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -93,10 +90,10 @@ def configure_package(configure_zookeeper):
 
         yield  # let the test session execute
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
-
+        return
 
 @pytest.mark.sanity
+@pytest.mark.pxkafka
 @pytest.mark.zookeeper
 def test_zookeeper_reresolution():
 
@@ -122,3 +119,10 @@ def test_zookeeper_reresolution():
 
     for id in range(0, 3):
         check_broker(id)
+
+@pytest.mark.sanity
+@pytest.mark.pxkafka
+@pytest.mark.zookeeper
+def uninstall_kafka():
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+    sdk_install.uninstall(ZK_PACKAGE, ZK_SERVICE_NAME)


### PR DESCRIPTION
Added separate functions for uninstall every framework in order to keep the setup in same state on failure.
Avoided Active Directory related tests from all frameworks.
The AD related tests will be added on need basis.

Signed-off-by: Jitendra Pawar <jitendra.pawar@gmail.com>