### PR TITLE
Update test image with a fixed tag

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -281,5 +281,5 @@ docker run --rm \
     -t \
     $DOCKER_INTERACTIVE_FLAGS \
     $DOCKER_ARGS \
-    mesosphere/dcos-commons:latest \
+    portworx/dcos-commons:1.3-0.40.5 \
     $DOCKER_COMMAND


### PR DESCRIPTION
latest tag from mesosphere repo has different library versions which doesn't
work with the current tests