### PR TITLE
Fixes for PTX-1213 : hdfs pytest testsuite issues

### DIFF
--- a/frameworks/hdfs/tests/test_overlay.py
+++ b/frameworks/hdfs/tests/test_overlay.py
@@ -26,7 +26,7 @@ def configure_package(configure_security):
 
         yield  # let the test session execute
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        return
 
 
 @pytest.fixture(autouse=True)
@@ -126,3 +126,8 @@ def wait_for_failover_to_complete(namenode):
 
 def get_unique_filename(prefix: str) -> str:
     return "{}.{}".format(prefix, str(uuid.uuid4()))
+
+@pytest.mark.overlay
+@pytest.mark.sanity
+def test_uninstall_hdfs():
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)

--- a/frameworks/hdfs/tests/test_sanity.py
+++ b/frameworks/hdfs/tests/test_sanity.py
@@ -41,7 +41,7 @@ def configure_package(configure_security):
 
         yield  # let the test session execute
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+        return
 
 
 @pytest.fixture(autouse=True)
@@ -82,9 +82,9 @@ def test_endpoints():
     for i in range(2):
         name_node = 'name-{}-node'.format(i)
         expect['dfs.namenode.rpc-address.hdfs.{}'.format(name_node)] = sdk_hosts.autoip_host(
-            foldered_name, name_node, 9001)
+            foldered_name, name_node, 10001)
         expect['dfs.namenode.http-address.hdfs.{}'.format(name_node)] = sdk_hosts.autoip_host(
-            foldered_name, name_node, 9002)
+            foldered_name, name_node, 10002)
     check_properties(hdfs_site, expect)
 
 
@@ -396,3 +396,8 @@ def replace_name_node(index):
     sdk_tasks.check_tasks_updated(foldered_name, name_node_name, name_id)
     sdk_tasks.check_tasks_not_updated(foldered_name, 'journal', journal_ids)
     sdk_tasks.check_tasks_not_updated(foldered_name, 'data', data_ids)
+
+@pytest.mark.sanity
+def test_uninstall_hdfs():
+    foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+    sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)


### PR DESCRIPTION
Now the test should be run using "not auth" in order to skip auth related tests.

Signed-off-by: Jitendra Pawar <jitendra@portworx.com>