### PR TITLE
PTX-1212 Made changes in kafka tests 

### DIFF
--- a/frameworks/kafka/tests/test_active_directory_auth.py
+++ b/frameworks/kafka/tests/test_active_directory_auth.py
@@ -124,6 +124,7 @@ def kafka_client(kerberos, kafka_server):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
+@pytest.mark.auth
 def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
     client_id = kafka_client["id"]
 

--- a/frameworks/kafka/tests/test_active_directory_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_active_directory_zookeeper_auth.py
@@ -165,6 +165,7 @@ def kafka_client(kerberos, kafka_server):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
+@pytest.mark.auth
 def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
     client_id = kafka_client["id"]
 

--- a/frameworks/kafka/tests/test_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_kerberos_auth.py
@@ -126,6 +126,7 @@ def kafka_client(kerberos, kafka_server):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
+@pytest.mark.auth
 def test_no_vip(kafka_client, kafka_server, kerberos):
     endpoints = sdk_networks.get_and_test_endpoints(kafka_server["package_name"], kafka_server["service"]["name"], "broker", 2)
     assert "vip" not in endpoints
@@ -134,6 +135,7 @@ def test_no_vip(kafka_client, kafka_server, kerberos):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
+@pytest.mark.auth
 def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
     client_id = kafka_client["id"]
 

--- a/frameworks/kafka/tests/test_kerberos_authz.py
+++ b/frameworks/kafka/tests/test_kerberos_authz.py
@@ -135,6 +135,7 @@ def kafka_client(kerberos, kafka_server):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
+@pytest.mark.auth
 def test_authz_acls_required(kafka_client, kafka_server, kerberos):
     client_id = kafka_client["id"]
 

--- a/frameworks/kafka/tests/test_overlay.py
+++ b/frameworks/kafka/tests/test_overlay.py
@@ -20,7 +20,7 @@ def configure_package(configure_security):
 
         yield  # let the test session execute
     finally:
-        install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        return
 
 
 @pytest.mark.overlay
@@ -86,3 +86,8 @@ def test_topic_create_overlay():
 @pytest.mark.dcos_min_version('1.9')
 def test_topic_delete_overlay():
     test_utils.delete_topic(config.EPHEMERAL_TOPIC_NAME)
+
+@pytest.mark.sanity
+@pytest.mark.overlay
+def test_uninstall_kafka():
+    install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)

--- a/frameworks/kafka/tests/test_rack_awareness.py
+++ b/frameworks/kafka/tests/test_rack_awareness.py
@@ -10,6 +10,7 @@ from tests import config, test_utils
 
 
 @pytest.mark.sanity
+@pytest.mark.rack
 @pytest.mark.dcos_min_version('1.11')
 @sdk_utils.dcos_ee_only
 def test_zones_not_referenced_in_placement_constraints():
@@ -45,6 +46,7 @@ def test_zones_not_referenced_in_placement_constraints():
 
 
 @pytest.mark.sanity
+@pytest.mark.rack
 @pytest.mark.dcos_min_version('1.11')
 @sdk_utils.dcos_ee_only
 def test_zones_referenced_in_placement_constraints():

--- a/frameworks/kafka/tests/test_sanity.py
+++ b/frameworks/kafka/tests/test_sanity.py
@@ -31,7 +31,7 @@ def configure_package(configure_security):
 
         yield  # let the test session execute
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)
+        return
 
 
 @pytest.mark.sanity
@@ -240,3 +240,9 @@ def test_metrics():
         config.DEFAULT_KAFKA_TIMEOUT,
         expected_metrics_exist
     )
+@pytest.mark.smoke
+@pytest.mark.sanity
+@pytest.mark.metrics
+def test_uninstall_kafka():
+    foldered_name = sdk_utils.get_foldered_name(config.SERVICE_NAME)
+    sdk_install.uninstall(config.PACKAGE_NAME, foldered_name)

--- a/frameworks/kafka/tests/test_ssl_auth.py
+++ b/frameworks/kafka/tests/test_ssl_auth.py
@@ -102,6 +102,7 @@ def setup_principals(kafka_client):
 @pytest.mark.dcos_min_version('1.10')
 @pytest.mark.ee_only
 @pytest.mark.sanity
+@pytest.mark.auth
 def test_authn_client_can_read_and_write(kafka_client, service_account, setup_principals):
     try:
         sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
@@ -152,6 +153,7 @@ def test_authn_client_can_read_and_write(kafka_client, service_account, setup_pr
 @pytest.mark.dcos_min_version('1.10')
 @pytest.mark.ee_only
 @pytest.mark.sanity
+@pytest.mark.auth
 def test_authz_acls_required(kafka_client, service_account, setup_principals):
     client_id = kafka_client["id"]
 
@@ -225,6 +227,7 @@ def test_authz_acls_required(kafka_client, service_account, setup_principals):
 @pytest.mark.dcos_min_version('1.10')
 @pytest.mark.ee_only
 @pytest.mark.sanity
+@pytest.mark.auth
 def test_authz_acls_not_required(kafka_client, service_account, setup_principals):
     client_id = kafka_client["id"]
 

--- a/frameworks/kafka/tests/test_ssl_kerberos_auth.py
+++ b/frameworks/kafka/tests/test_ssl_kerberos_auth.py
@@ -163,6 +163,7 @@ def kafka_client(kerberos, kafka_server):
 @pytest.mark.dcos_min_version('1.10')
 @sdk_utils.dcos_ee_only
 @pytest.mark.sanity
+@pytest.mark.auth
 def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
     client_id = kafka_client["id"]
 

--- a/frameworks/kafka/tests/test_tls.py
+++ b/frameworks/kafka/tests/test_tls.py
@@ -28,8 +28,7 @@ def service_account(configure_security):
             "security org groups add_user superusers {name}".format(name=name))
         yield name
     finally:
-        sdk_security.delete_service_account(
-            service_account_name=name, service_account_secret=name)
+        return
 
 
 @pytest.fixture(scope='module')
@@ -57,7 +56,7 @@ def kafka_service_tls(service_account):
 
         yield service_account
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        return
 
 
 @pytest.mark.tls
@@ -92,3 +91,13 @@ def test_producer_over_tls(kafka_service_tls):
     write_info = sdk_cmd.svc_cli(config.PACKAGE_NAME, config.SERVICE_NAME, 'topic producer_test_tls {} {}'.format(config.DEFAULT_TOPIC_NAME, num_messages), json=True)
     assert len(write_info) == 1
     assert write_info['message'].startswith('Output: {} records sent'.format(num_messages))
+
+@pytest.mark.tls
+@pytest.mark.smoke
+@pytest.mark.sanity
+@sdk_utils.dcos_ee_only
+@pytest.mark.dcos_min_version('1.10')
+def test_tls_uninstall_kafka():
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+    sdk_security.delete_service_account(
+            service_account_name=config.SERVICE_NAME, service_account_secret=config.SERVICE_NAME)

--- a/frameworks/kafka/tests/test_topics.py
+++ b/frameworks/kafka/tests/test_topics.py
@@ -32,7 +32,7 @@ def kafka_server(configure_security):
 
         yield {"package_name": config.PACKAGE_NAME, "service": {"name": config.SERVICE_NAME}}
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        return
 
 
 @pytest.mark.smoke
@@ -167,3 +167,7 @@ def test_no_unavailable_partitions_exist(kafka_server: dict):
         'topic unavailable_partitions', json=True)
 
     assert partition_info == {"message": ""}
+
+@pytest.mark.sanity
+def test_topics_uninstall_kafka():
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)

--- a/frameworks/kafka/tests/test_zookeeper.py
+++ b/frameworks/kafka/tests/test_zookeeper.py
@@ -65,10 +65,7 @@ def configure_zookeeper(configure_security, install_zookeeper_stub):
 
         yield
     finally:
-        sdk_install.uninstall(ZK_PACKAGE, ZK_SERVICE_NAME)
-        if sdk_utils.is_strict_mode():
-            sdk_security.delete_service_account(
-                service_account_name=zk_account, service_account_secret=zk_secret)
+        return
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -93,7 +90,7 @@ def configure_package(configure_zookeeper):
 
         yield  # let the test session execute
     finally:
-        sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+        return
 
 
 @pytest.mark.sanity
@@ -122,3 +119,9 @@ def test_zookeeper_reresolution():
 
     for id in range(0, 3):
         check_broker(id)
+
+@pytest.mark.sanity
+@pytest.mark.zookeeper
+def uninstall_kafka():
+    sdk_install.uninstall(config.PACKAGE_NAME, config.SERVICE_NAME)
+    sdk_install.uninstall(ZK_PACKAGE, ZK_SERVICE_NAME)

--- a/frameworks/kafka/tests/test_zookeeper_auth.py
+++ b/frameworks/kafka/tests/test_zookeeper_auth.py
@@ -202,6 +202,7 @@ def kafka_client(kerberos, kafka_server):
 @sdk_utils.dcos_ee_only
 @pytest.mark.zookeeper
 @pytest.mark.sanity
+@pytest.mark.auth
 def test_client_can_read_and_write(kafka_client, kafka_server, kerberos):
     client_id = kafka_client["id"]
 


### PR DESCRIPTION
added auth tag for active directory related tests
added rack tag for rack tests
Moved uninstall at appropriate place such that the test exccution can not uninstall the
kafka service in case of any test failure

The test can be run with these params -
sanity and not aws and not azure and not rack and not auth

Signed-off-by: Jitendra Pawar <jitendra@portworx.com>